### PR TITLE
refactor: organize pages and components

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,9 @@
 import { useState } from "react";
 import { NavLink, Routes, Route, useLocation } from "react-router-dom";
-import ConfigEditor from "./ConfigEditor";
-import { Dashboard } from "./Dashboard";
-import LogsStub from "./LogsStub";
-import AboutStub from "./AboutStub";
+import ConfigEditor from "./pages/ConfigEditor";
+import Dashboard from "./pages/Dashboard";
+import Logs from "./pages/Logs";
+import About from "./pages/About";
 
 export default function App() {
   const [sidebarOpen, setSidebarOpen] = useState(true);
@@ -116,8 +116,8 @@ export default function App() {
           <Routes>
             <Route path="/" element={<Dashboard />} />
             <Route path="/config" element={<ConfigEditor />} />
-            <Route path="/logs" element={<LogsStub />} />
-            <Route path="/about" element={<AboutStub />} />
+            <Route path="/logs" element={<Logs />} />
+            <Route path="/about" element={<About />} />
           </Routes>
         </main>
       </div>

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,0 +1,15 @@
+import { ReactNode } from "react";
+
+type Props = {
+  children: ReactNode;
+  className?: string;
+};
+
+export default function Card({ children, className = "" }: Props) {
+  return (
+    <section className={`bg-white/80 backdrop-blur rounded-xl shadow-sm ring-1 ring-slate-200 p-4 ${className}`}>
+      {children}
+    </section>
+  );
+}
+

--- a/src/components/ResourcePicker.tsx
+++ b/src/components/ResourcePicker.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { type Item, searchItems, getItemsByIds, loadSelection, saveSelection } from "../api";
 
 type Props = {
@@ -11,7 +11,7 @@ type Props = {
 
 const cx = (...c: Array<string | false | null | undefined>) => c.filter(Boolean).join(" ");
 
-export default function RessourcesPicker({
+export default function ResourcePicker({
   limit = 20,
   defaultSelectedIds = [],
   onChangeSelected,
@@ -31,7 +31,7 @@ export default function RessourcesPicker({
       const m = new Map<number, Item>();
       items.forEach((it) => m.set(it.id, it));
       setSelectedMap(m);
-      props.onChangeSelected?.(Array.from(m.values()));
+      onChangeSelected?.(Array.from(m.values()));
     } catch (e) {
       console.error("Reload selection failed:", e);
       // Optionnel: toast UI

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,10 +1,13 @@
-export default function AboutStub() {
+import Card from "../components/Card";
+
+export default function About() {
   return (
-    <section className="bg-white/80 backdrop-blur rounded-xl shadow-sm ring-1 ring-slate-200 p-4">
+    <Card>
       <h2 className="text-base font-semibold mb-2">À propos</h2>
       <p className="text-sm text-slate-600">
         Petite UI Tailwind. Menu latéral repliable, barre de titre collante, cartes et ombres.
       </p>
-    </section>
-  )
+    </Card>
+  );
 }
+

--- a/src/pages/ConfigEditor.tsx
+++ b/src/pages/ConfigEditor.tsx
@@ -7,7 +7,7 @@ import {
   cmdPatchConfig,
   cmdScreenshot,
   sendCommand, // pour save_template (optionnel)
-} from "./api";
+} from "../api";
 import * as YAML from "js-yaml";
 
 /** Types alignés sur ton YAML */

--- a/src/pages/Logs.tsx
+++ b/src/pages/Logs.tsx
@@ -1,8 +1,11 @@
-export default function LogsStub() {
+import Card from "../components/Card";
+
+export default function Logs() {
   return (
-    <section className="bg-white/80 backdrop-blur rounded-xl shadow-sm ring-1 ring-slate-200 p-4">
+    <Card>
       <h2 className="text-base font-semibold mb-2">Journaux</h2>
       <p className="text-sm text-slate-600">Ici tu pourras afficher des logs globaux.</p>
-    </section>
-  )
+    </Card>
+  );
 }
+


### PR DESCRIPTION
## Summary
- move top-level pages into `src/pages` and update router imports
- add reusable `Card` component and integrate in pages
- rename `RessourcesPicker` to `ResourcePicker` and fix selection callback

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 30 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68b833307a308331b92172002a060ef7