### PR TITLE
Add price history graph page

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,13 +13,17 @@
     "js-yaml": "^4.1.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "react-router-dom": "^6.27.0"
+    "react-router-dom": "^6.27.0",
+    "chart.js": "^4.4.0",
+    "react-chartjs-2": "^5.2.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
     "@tailwindcss/postcss": "^4.1.12",
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
+    "@types/react-router-dom": "^5.3.3",
+    "@types/js-yaml": "^4.0.9",
     "@vitejs/plugin-react": "^5.0.0",
     "autoprefixer": "^10.4.21",
     "eslint": "^9.33.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,12 +4,14 @@ import ConfigEditor from "./pages/ConfigEditor";
 import Dashboard from "./pages/Dashboard";
 import Logs from "./pages/Logs";
 import About from "./pages/About";
+import Prices from "./pages/Prices";
 
 export default function App() {
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const location = useLocation();
   const titles: Record<string, string> = {
     "/": "Tableau de bord",
+    "/prices": "Historique des prix",
     "/config": "Éditeur de configuration",
     "/logs": "Journaux",
     "/about": "À propos",
@@ -66,6 +68,20 @@ export default function App() {
                 <span className="truncate">Tableau de bord</span>
               </NavLink>
               <NavLink
+                to="/prices"
+                className={({ isActive }: { isActive: boolean }) =>
+                  [
+                    "flex items-center gap-2 px-3 py-2 rounded-lg border text-sm",
+                    isActive
+                      ? "bg-sky-50 border-sky-200 text-sky-800"
+                      : "bg-white border-slate-200 hover:bg-slate-50",
+                  ].join(" ")
+                }
+              >
+                <span className="shrink-0">📈</span>
+                <span className="truncate">Prix</span>
+              </NavLink>
+              <NavLink
                 to="/config"
                 className={({ isActive }: { isActive: boolean }) =>
                   [
@@ -115,6 +131,7 @@ export default function App() {
         <main className="flex-1 overflow-y-auto p-4">
           <Routes>
             <Route path="/" element={<Dashboard />} />
+            <Route path="/prices" element={<Prices />} />
             <Route path="/config" element={<ConfigEditor />} />
             <Route path="/logs" element={<Logs />} />
             <Route path="/about" element={<About />} />

--- a/src/api.ts
+++ b/src/api.ts
@@ -168,3 +168,45 @@ export async function saveSelection(ids: number[]): Promise<{ ok: boolean; count
   );
   return data as { ok: boolean; count: number };
 }
+
+// PRICES -------------------------------------------------------------------
+
+export type HdvResource = {
+  slug: string;
+  points: number;
+  last_seen: string;
+  last_prices: Record<string, { price: number; datetime: string }>;
+};
+
+export async function listHdvResources(limit = 1000, qty?: string): Promise<HdvResource[]> {
+  const url = new URL("/api/hdv/resources", API_BASE);
+  url.searchParams.set("limit", String(limit));
+  if (qty) url.searchParams.set("qty", qty);
+  const data = await fetchJSON(url.toString());
+  return (data?.resources ?? []) as HdvResource[];
+}
+
+export type TimeseriesPoint = { t: string; value?: number; price?: number };
+export type TimeseriesSeries = {
+  slug: string;
+  qty: string;
+  bucket: string;
+  agg: string | null;
+  points: TimeseriesPoint[];
+};
+
+export async function getHdvTimeseries(
+  slugs: string[],
+  qty?: string,
+  bucket = "day",
+  agg = "avg"
+): Promise<TimeseriesSeries[]> {
+  if (!slugs.length) return [];
+  const url = new URL("/api/hdv/timeseries", API_BASE);
+  url.searchParams.set("slugs", slugs.join(","));
+  if (qty) url.searchParams.set("qty", qty);
+  if (bucket) url.searchParams.set("bucket", bucket);
+  if (agg) url.searchParams.set("agg", agg);
+  const data = await fetchJSON(url.toString());
+  return (data?.series ?? []) as TimeseriesSeries[];
+}

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import { type ReactNode } from "react";
 
 type Props = {
   children: ReactNode;

--- a/src/pages/ConfigEditor.tsx
+++ b/src/pages/ConfigEditor.tsx
@@ -404,7 +404,7 @@ export default function ConfigEditor() {
       setBusy(false);
     }
   }
-  function onTemplateCropped(dataUrl: string, naturalRect: { x: number; y: number; w: number; h: number }) {
+  function onTemplateCropped(dataUrl: string) {
     if (!cropForTemplate) return;
     setCropResult(dataUrl);
     const name = cropForTemplate;
@@ -828,7 +828,7 @@ export default function ConfigEditor() {
             setCropImg("");
             setCropResult("");
           }}
-          onCropped={(dataUrl, rect) => onTemplateCropped(dataUrl, rect)}
+            onCropped={(dataUrl) => onTemplateCropped(dataUrl)}
           onDownload={() => {
             const fn = suggestedFilename || `${cropForTemplate}.png`;
             if (cropResult) downloadDataUrl(fn, cropResult);

--- a/src/pages/Prices.tsx
+++ b/src/pages/Prices.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useState } from "react";
+import {
+  listHdvResources,
+  getHdvTimeseries,
+  type HdvResource,
+  type TimeseriesSeries,
+} from "../api";
+import {
+  Chart as ChartJS,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Tooltip,
+  Legend,
+} from "chart.js";
+import { Line } from "react-chartjs-2";
+
+ChartJS.register(LinearScale, PointElement, LineElement, Tooltip, Legend);
+
+const COLORS = ["#3b82f6", "#10b981", "#ef4444", "#f59e0b", "#8b5cf6"];
+
+export default function Prices() {
+  const [resources, setResources] = useState<HdvResource[]>([]);
+  const [selected, setSelected] = useState<string[]>([]);
+  const [series, setSeries] = useState<TimeseriesSeries[]>([]);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await listHdvResources();
+        setResources(res);
+      } catch (e) {
+        console.error("Failed to load resources", e);
+      }
+    })();
+  }, []);
+
+  useEffect(() => {
+    if (selected.length === 0) {
+      setSeries([]);
+      return;
+    }
+    (async () => {
+      try {
+        const ts = await getHdvTimeseries(selected, "x1", "day", "avg");
+        setSeries(ts);
+      } catch (e) {
+        console.error("Failed to load timeseries", e);
+        setSeries([]);
+      }
+    })();
+  }, [selected]);
+
+  const chartData = {
+    datasets: series.map((s, idx) => ({
+      label: s.slug,
+      data: s.points.map((p) => ({
+        x: new Date(p.t).getTime(),
+        y: p.price ?? p.value ?? 0,
+      })),
+      borderColor: COLORS[idx % COLORS.length],
+      backgroundColor: COLORS[idx % COLORS.length],
+      tension: 0.1,
+    })),
+  };
+
+  const chartOptions = {
+    parsing: false,
+    responsive: true,
+    scales: {
+      x: {
+        type: "linear" as const,
+        ticks: {
+          callback: (value: number) => new Date(value).toLocaleDateString(),
+        },
+      },
+      y: {
+        type: "linear" as const,
+      },
+    },
+    plugins: {
+      legend: { position: "bottom" as const },
+    },
+  };
+
+  const toggle = (slug: string, checked: boolean) => {
+    setSelected((prev) => {
+      if (checked) return [...prev, slug];
+      return prev.filter((s) => s !== slug);
+    });
+  };
+
+  return (
+    <div className="space-y-6">
+      <h2 className="text-lg font-semibold">Historique des prix</h2>
+      <div className="flex flex-wrap gap-4">
+        {resources.map((r) => (
+          <label key={r.slug} className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={selected.includes(r.slug)}
+              onChange={(e) => toggle(r.slug, e.target.checked)}
+            />
+            <span>{r.slug}</span>
+          </label>
+        ))}
+      </div>
+      <div className="border rounded-xl p-4 bg-white">
+        {series.length === 0 ? (
+          <div className="text-sm text-slate-500">Aucune donnée à afficher.</div>
+        ) : (
+          <Line data={chartData} options={chartOptions} />
+        )}
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add API helpers for hdv resource list and timeseries data
- implement price history page using these endpoints and render chart with react-chartjs-2
- add charting and type dependencies, fix minor type issues

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any & other lint errors in existing files)*
- `npm run build` *(fails: Cannot find module 'react-router-dom' types and chart.js modules)*

------
https://chatgpt.com/codex/tasks/task_e_68b84c2030748331835663043b959384