### PR TITLE
feat: add auto mode toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { NavLink, Routes, Route, useLocation } from "react-router-dom";
 import ConfigEditor from "./pages/ConfigEditor";
-import Dashboard from "./pages/Dashboard";
+import Home from "./pages/Home";
 import Logs from "./pages/Logs";
 import About from "./pages/About";
 import Prices from "./pages/Prices";
@@ -10,7 +10,7 @@ export default function App() {
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const location = useLocation();
   const titles: Record<string, string> = {
-    "/": "Tableau de bord",
+    "/": "Accueil",
     "/prices": "Historique des prix",
     "/config": "Éditeur de configuration",
     "/logs": "Journaux",
@@ -65,7 +65,7 @@ export default function App() {
                 }
               >
                 <span className="shrink-0">🏠</span>
-                <span className="truncate">Tableau de bord</span>
+                <span className="truncate">Accueil</span>
               </NavLink>
               <NavLink
                 to="/prices"
@@ -130,7 +130,7 @@ export default function App() {
         {/* ----- MAIN CONTENT ----- */}
         <main className="flex-1 overflow-y-auto p-4">
           <Routes>
-            <Route path="/" element={<Dashboard />} />
+            <Route path="/" element={<Home />} />
             <Route path="/prices" element={<Prices />} />
             <Route path="/config" element={<ConfigEditor />} />
             <Route path="/logs" element={<Logs />} />

--- a/src/api.ts
+++ b/src/api.ts
@@ -169,6 +169,25 @@ export async function saveSelection(ids: number[]): Promise<{ ok: boolean; count
   return data as { ok: boolean; count: number };
 }
 
+export async function loadAutoMode(): Promise<boolean> {
+  const url = new URL("/api/auto_mode", API_BASE);
+  const data = await fetchJSON(url.toString());
+  return !!data?.auto;
+}
+
+export async function saveAutoMode(auto: boolean): Promise<{ ok: boolean }> {
+  const url = new URL("/api/auto_mode", API_BASE);
+  const data = await fetchJSON(
+    url.toString(),
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ auto }),
+    }
+  );
+  return data as { ok: boolean };
+}
+
 // PRICES -------------------------------------------------------------------
 
 export type HdvResource = {


### PR DESCRIPTION
## Summary
- rename dashboard to home and adjust navigation
- add auto mode checkbox with backend persistence
- auto-start script when agent connects and auto mode is enabled

## Testing
- `npm test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c00cbd2bc88331a865c39f825d3368