### PR TITLE
feat: localize price chart timestamps

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -218,7 +218,9 @@ export async function getHdvTimeseries(
   slugs: string[],
   qty?: string,
   bucket = "day",
-  agg = "avg"
+  agg = "avg",
+  start?: string,
+  end?: string,
 ): Promise<TimeseriesSeries[]> {
   if (!slugs.length) return [];
   const url = new URL("/api/hdv/timeseries", API_BASE);
@@ -226,6 +228,8 @@ export async function getHdvTimeseries(
   if (qty) url.searchParams.set("qty", qty);
   if (bucket) url.searchParams.set("bucket", bucket);
   if (agg) url.searchParams.set("agg", agg);
+  if (start) url.searchParams.set("start", new Date(start).toISOString());
+  if (end) url.searchParams.set("end", new Date(end).toISOString());
   const data = await fetchJSON(url.toString());
   return (data?.series ?? []) as TimeseriesSeries[];
 }


### PR DESCRIPTION
## Summary
- show full timestamp in tooltips and axis ticks based on browser locale
- allow filtering price history with adjustable start/end time range
- pass optional start/end range to HDV timeseries API

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_68c1231fe5448331aac4189cf102c080