### PR TITLE
Affiche la moyenne et la médiane des prix

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -233,3 +233,28 @@ export async function getHdvTimeseries(
   const data = await fetchJSON(url.toString());
   return (data?.series ?? []) as TimeseriesSeries[];
 }
+
+export type HdvPriceStat = {
+  slug: string;
+  qty: string;
+  stat: string;
+  value: number | null;
+  points: number;
+};
+
+export async function getHdvPriceStat(
+  slug: string,
+  qty: string,
+  stat: "avg" | "median",
+  start?: string,
+  end?: string,
+): Promise<HdvPriceStat> {
+  const url = new URL("/api/hdv/price_stat", API_BASE);
+  url.searchParams.set("slug", slug);
+  url.searchParams.set("qty", qty);
+  url.searchParams.set("stat", stat);
+  if (start) url.searchParams.set("date_from", new Date(start).toISOString());
+  if (end) url.searchParams.set("date_to", new Date(end).toISOString());
+  const data = await fetchJSON(url.toString());
+  return data as HdvPriceStat;
+}


### PR DESCRIPTION
## Summary
- fetch average and median price statistics for selected resources
- allow toggling horizontal mean and median lines on the price history chart
- show chart timestamps in the user's local timezone

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68c13ce4ceac8331b8433add0845f4ba